### PR TITLE
ci: add Secret Scan gate

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,31 @@
+name: Secret Scan
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks (filesystem scan, license-free)
+        run: |
+          set -euo pipefail
+          TAG=$(curl -sSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)
+          NUM=${TAG#v}
+          echo "Using gitleaks ${TAG}"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${TAG}/gitleaks_${NUM}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          chmod +x /tmp/gitleaks
+          /tmp/gitleaks dir . --redact --no-banner --exit-code 1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,19 +13,26 @@ jobs:
     name: Secret Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      GITLEAKS_VERSION: 8.30.1
+      GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Run gitleaks (filesystem scan, license-free)
+      - name: Run gitleaks (filesystem scan, pinned + checksum-verified, license-free)
         run: |
           set -euo pipefail
-          TAG=$(curl -sSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)
-          NUM=${TAG#v}
-          echo "Using gitleaks ${TAG}"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${TAG}/gitleaks_${NUM}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${TARBALL}"
+          echo "Downloading gitleaks v${GITLEAKS_VERSION}"
+          curl --fail --location --silent --show-error \
+            --connect-timeout 15 --max-time 120 --retry 3 \
+            "$URL" -o /tmp/gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum --check --strict
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           chmod +x /tmp/gitleaks
-          /tmp/gitleaks dir . --redact --no-banner -v --exit-code 1
+          /tmp/gitleaks dir . --redact --no-banner --exit-code 1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -28,4 +28,4 @@ jobs:
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${TAG}/gitleaks_${NUM}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           chmod +x /tmp/gitleaks
-          /tmp/gitleaks dir . --redact --no-banner --exit-code 1
+          /tmp/gitleaks dir . --redact --no-banner -v --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+# gitleaks config — extends the default ruleset and allowlists vendored,
+# minified third-party bundles whose high-entropy minified identifiers trip
+# the generic-api-key rule as false positives (not real secrets).
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Vendored minified third-party assets (e.g. xterm.js) — false positives, not secrets"
+paths = [
+  '''packages/vscode/media/.*''',
+]


### PR DESCRIPTION
Adds a license-free gitleaks filesystem secret scan as a required CI gate (org-standard rollout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated secret scanning in the repository to detect and prevent accidental exposure of sensitive credentials in commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->